### PR TITLE
Upgrade Ludwig version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM python:3.10-slim
 
-ARG VERSION=0.6.1
+ARG VERSION=0.10
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends build-essential cmake git unzip
 
-RUN export HOROVOD_WITH_PYTORCH=1 && \
-    pip install -U pip && \
-    pip install 'torch' 'git+https://github.com/goeckslab/model-unpickler.git' && \
+RUN pip install -U pip && \
+    pip install 'git+https://github.com/goeckslab/model-unpickler.git' && \
     pip install 'git+https://github.com/goeckslab/smart-report.git@17df590f3ceb065add099f37b4874c85bd275014' && \
-    pip install 'horovod[pytorch]' && \
     pip install 'ludwig[full]'==$VERSION && \
     pip cache purge
 
 RUN apt-get purge -y build-essential cmake && apt-get -y autoremove && apt-get clean
+

--- a/tools/ludwig_experiment.py
+++ b/tools/ludwig_experiment.py
@@ -11,7 +11,7 @@ from ludwig.globals import (
     TEST_STATISTICS_FILE_NAME,
     TRAIN_SET_METADATA_FILE_NAME,
 )
-from ludwig.visualize import visualizations_registry
+from ludwig.visualize import get_visualizations_registry
 
 from model_unpickler import SafeUnpickler
 
@@ -75,7 +75,7 @@ def make_visualizations(ludwig_output_directory_name):
     )
 
     for viz in visualizations:
-        viz_func = visualizations_registry[viz]
+        viz_func = get_visualizations_registry()[viz]
         try:
             viz_func(
                 training_statistics=[training_statistics],

--- a/tools/ludwig_macros.xml
+++ b/tools/ludwig_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@LUDWIG_VERSION@">0.6.1</token>
+    <token name="@LUDWIG_VERSION@">0.10</token>
 
     <token name="@SUFFIX@">0</token>
 

--- a/tools/ludwig_render_config.py
+++ b/tools/ludwig_render_config.py
@@ -10,7 +10,7 @@ from ludwig.constants import (
     PROC_COLUMN,
     TRAINER,
 )
-from ludwig.utils.defaults import merge_with_defaults
+from ludwig.schema.model_types.utils import merge_with_defaults
 
 import yaml
 


### PR DESCRIPTION
ludwig[full] will install torch and Ray. Ludwig has strong support for Ray, a framework for distributed computing, so we are not going to use Horovod. But Ray doesn't support python 3.11 now, so we are still using python 3.10. 