### PR TITLE
run actions for main only

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,11 @@
 name: Galaxy Tool Linting and Tests for push and PR
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_22.05


### PR DESCRIPTION
I think we don't need the check for other branch for now and it will minimize the fail messages to our email. 